### PR TITLE
hof/gen: support datafiles in adhoc mode

### DIFF
--- a/.hof/shadow/cli/cmd/hof/cmd/gen.go
+++ b/.hof/shadow/cli/cmd/hof/cmd/gen.go
@@ -44,12 +44,16 @@ var genLong = `hof unifies CUE with Go's text/template system and diff3
   # Templated output path, braces need quotes
   -T templateA.txt:='{{ .name | lower }}.txt'
 
+	# Data Files are created when no template
+  -T :sub.val='{{ .name | lower }}.json'
+
   # Repeated templates are used when
   # 1. the output has a '[]' prefix
   # 2. the input is a list or array
   #   The template will be processed per entry
   #   This also requires using a templated outpath
   -T template.txt:items='[]out/{{ .filepath }}.txt'
+  -T :items='[]out/{{ .filepath }}.yaml'
 
   # Output everything to a directory (out name is the same)
   -O out -T types.go -T handlers.go

--- a/cmd/hof/cmd/gen.go
+++ b/cmd/hof/cmd/gen.go
@@ -45,12 +45,16 @@ var genLong = `hof unifies CUE with Go's text/template system and diff3
   # Templated output path, braces need quotes
   -T templateA.txt:='{{ .name | lower }}.txt'
 
+	# Data Files are created when no template
+  -T :sub.val='{{ .name | lower }}.json'
+
   # Repeated templates are used when
   # 1. the output has a '[]' prefix
   # 2. the input is a list or array
   #   The template will be processed per entry
   #   This also requires using a templated outpath
   -T template.txt:items='[]out/{{ .filepath }}.txt'
+  -T :items='[]out/{{ .filepath }}.yaml'
 
   # Output everything to a directory (out name is the same)
   -O out -T types.go -T handlers.go

--- a/design/cmds/gen.cue
+++ b/design/cmds/gen.cue
@@ -151,12 +151,16 @@ hof unifies CUE with Go's text/template system and diff3
   # Templated output path, braces need quotes
   -T templateA.txt:='{{ .name | lower }}.txt'
 
+	# Data Files are created when no template
+  -T :sub.val='{{ .name | lower }}.json'
+
   # Repeated templates are used when
   # 1. the output has a '[]' prefix
   # 2. the input is a list or array
   #   The template will be processed per entry
   #   This also requires using a templated outpath
   -T template.txt:items='[]out/{{ .filepath }}.txt'
+  -T :items='[]out/{{ .filepath }}.yaml'
 
   # Output everything to a directory (out name is the same)
   -O out -T types.go -T handlers.go

--- a/docs/code/cmd-help/gen
+++ b/docs/code/cmd-help/gen
@@ -31,12 +31,16 @@ hof unifies CUE with Go's text/template system and diff3
   # Templated output path, braces need quotes
   -T templateA.txt:='{{ .name | lower }}.txt'
 
+	# Data Files are created when no template
+  -T :sub.val='{{ .name | lower }}.json'
+
   # Repeated templates are used when
   # 1. the output has a '[]' prefix
   # 2. the input is a list or array
   #   The template will be processed per entry
   #   This also requires using a templated outpath
   -T template.txt:items='[]out/{{ .filepath }}.txt'
+  -T :items='[]out/{{ .filepath }}.yaml'
 
   # Output everything to a directory (out name is the same)
   -O out -T types.go -T handlers.go

--- a/docs/content/getting-started/code-generation.md
+++ b/docs/content/getting-started/code-generation.md
@@ -103,6 +103,27 @@ $ hof gen data.cue schema.cue -T template.txt="{{ .name }}.txt"
 These can be combined so you can control
 where output goes and how files are named.
 
+{{<codeInner title="> terminal" lang="sh">}}
+$ hof gen data.cue schema.cue \
+  -O out \
+  -T template.txt="{{ .name }}.txt"
+{{</codeInner>}}
+
+### Write Data Files
+
+Omit the template path at the beginning
+and `hof` will infer the data format
+from the outpath file extension
+
+{{<codeInner title="> terminal" lang="sh">}}
+# full value to a single data file
+$ hof gen data.cue schema.cue -T =data.yaml
+
+# data file per item in iterable value
+$ hof gen data.cue schema.cue \
+  -O out \
+  -T :items="[]{{ .name }}.json"
+{{</codeInner>}}
 
 ### Multiple Templates
 
@@ -111,7 +132,7 @@ Each is independent and can have different options applied to
 the data and schemas from the CUE entrypoints. (we'll see this below)
 
 {{<codeInner title="> terminal" lang="sh">}}
-$ hof gen data.cue schema.cue -T template.txt -T debug.yaml -O out/
+$ hof gen data.cue schema.cue -T template.txt -T =debug.yaml -O out/
 {{</codeInner>}}
 
 

--- a/lib/fmt/fmtrs.go
+++ b/lib/fmt/fmtrs.go
@@ -404,7 +404,6 @@ func FormatSource(filename string, content []byte, fmtrName string, config inter
 		return content, fmt.Errorf("error while formatting %s", filename)
 	}
 
-	fmt.Println("  lens:", len(content), len(body), resp.StatusCode, string(body))
 	content = body
 
 	if !bytes.HasSuffix(content, []byte{'\n'}) {

--- a/test/render/datafiles.txt
+++ b/test/render/datafiles.txt
@@ -1,0 +1,32 @@
+exec hof gen data.cue -T =all.yaml
+cmp all.yaml expected-all.yaml
+
+exec hof gen data.cue -T :vals=vals.yaml
+cmp vals.yaml expected-vals.yaml
+
+exec hof gen data.cue schema.cue -T =all.yaml
+cmp all.yaml expected-all.yaml
+
+-- schema.cue --
+vals: [...{ name: string, data: int }]
+-- data.cue --
+foo: "bar"
+vals: [{
+	name: "a"
+	data: 1
+},{
+	name: "b"
+	data: 2
+}]
+-- expected-all.yaml --
+foo: bar
+vals:
+  - name: a
+    data: 1
+  - name: b
+    data: 2
+-- expected-vals.yaml --
+- name: a
+  data: 1
+- name: b
+  data: 2

--- a/test/render/repeated-datafile.txt
+++ b/test/render/repeated-datafile.txt
@@ -1,0 +1,19 @@
+exec hof gen data.cue -T :vals='[]{{ .name }}.yaml'
+cmp a.yaml expected-a.yaml
+cmp b.yaml expected-b.yaml
+
+-- data.cue --
+vals: [{
+	name: "a"
+	data: 1
+},{
+	name: "b"
+	data: 2
+}]
+
+-- expected-a.yaml --
+name: a
+data: 1
+-- expected-b.yaml --
+name: b
+data: 2


### PR DESCRIPTION
We can infer data file mode in `-T :entries="{{ .name }}.yaml"` by the missing template path. We use the outpath file extension as the data file format.