### PR TITLE
hof/mod: centralize the path & ref manipulation around cache

### DIFF
--- a/lib/mod/get.go
+++ b/lib/mod/get.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	gomod "golang.org/x/mod/module"
+	// gomod "golang.org/x/mod/module"
 	"golang.org/x/mod/semver"
 
 	"github.com/hofstadter-io/hof/cmd/hof/flags"
@@ -59,11 +59,13 @@ func Get(module string, rflags flags.RootPflagpole, gflags flags.Mod__GetFlagpol
 	return cm.Vendor("", rflags.Verbosity)
 }
 
-func updateOne(cm *CueMod, path, ver string, rflags flags.RootPflagpole, gflags flags.Mod__GetFlagpole) (error) {
+func updateOne(cm *CueMod, path, ver string, rflags flags.RootPflagpole, gflags flags.Mod__GetFlagpole) (err error) {
+	/*
 	err := gomod.CheckPath(path)
 	if err != nil {
 		return fmt.Errorf("bad module name %q, should have domain format 'domain.com/...'", path)
 	}
+	*/
 
 	if path == cm.Module {
 		return fmt.Errorf("cannot get current module")

--- a/lib/mod/get.go
+++ b/lib/mod/get.go
@@ -15,7 +15,14 @@ func Get(module string, rflags flags.RootPflagpole, gflags flags.Mod__GetFlagpol
 	upgradeHofMods()
 
 	path, ver := module, ""
-	parts := strings.Split(module, "@")
+
+	// figure out parts
+	parts := []string{module}
+	if strings.Contains(module, "@") {
+		parts = strings.Split(module, "@")
+	} else if strings.Contains(module, ":") {
+		parts = strings.Split(module, ":")
+	}
 	if len(parts) == 2 {
 		path, ver = parts[0], parts[1]
 	}
@@ -71,7 +78,7 @@ func updateOne(cm *CueMod, path, ver string, rflags flags.RootPflagpole, gflags 
 		return fmt.Errorf("cannot get current module")
 	}
 
-	// check for indirect and delete
+	// check for indirect and delete, the user is making it direct
 	_, ok := cm.Indirect[path]
 	if ok {
 		delete(cm.Indirect, path)

--- a/lib/mod/init.go
+++ b/lib/mod/init.go
@@ -6,7 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	gomod "golang.org/x/mod/module"
+	// gomod "golang.org/x/mod/module"
 
 	"github.com/hofstadter-io/hof/cmd/hof/flags"
 	"github.com/hofstadter-io/hof/cmd/hof/verinfo"
@@ -16,13 +16,15 @@ var initFileContent = `module: %q
 cue: %q
 `
 
-func Init(module string, rflags flags.RootPflagpole) (error) {
+func Init(module string, rflags flags.RootPflagpole) (err error) {
 	upgradeHofMods()
 
+	/*
 	err := gomod.CheckPath(module)
 	if err != nil {
 		return fmt.Errorf("bad module name %q, should have domain format 'domain.com/...'", module)
 	}
+	*/
 
 	_, err = os.Lstat("cue.mod")
 	if err != nil {

--- a/lib/repos/cache/info.go
+++ b/lib/repos/cache/info.go
@@ -12,6 +12,9 @@ import (
 
 
 func GetLatestTag(path string, pre bool) (string, error) {
+	if debug {
+		fmt.Println("cache.GetLatestBranch", path, pre)
+	}
 	_, err := FetchRepoSource(path, "")
 	if err != nil {
 		return "", err
@@ -52,6 +55,9 @@ func GetLatestTag(path string, pre bool) (string, error) {
 }
 
 func GetLatestBranch(path, branch string) (string, error) {
+	if debug {
+		fmt.Println("cache.GetLatestBranch", path, branch)
+	}
 	// sync
 	_, err := FetchRepoSource(path, "")
 	if err != nil {

--- a/lib/repos/cache/info.go
+++ b/lib/repos/cache/info.go
@@ -8,13 +8,72 @@ import (
 	gogit "github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
 	"golang.org/x/mod/semver"
+
+	"github.com/hofstadter-io/hof/lib/repos/oci"
+	"github.com/hofstadter-io/hof/lib/repos/remote"
 )
 
 
 func GetLatestTag(path string, pre bool) (string, error) {
 	if debug {
-		fmt.Println("cache.GetLatestBranch", path, pre)
+		fmt.Println("cache.GetLatestTag", path, pre)
 	}
+
+	rmt, err := remote.Parse(path)
+	if err != nil {
+		return "", err
+	}
+
+	kind, err := rmt.Kind()
+	if err != nil {
+		return "", err
+	}
+
+	switch kind {
+	case remote.KindGit:
+		return GetLatestTagGit(path, pre)
+	case remote.KindOCI:
+		return GetLatestTagOCI(path, pre)
+	}
+
+	panic("cache.GetLatestTag: should not get here")
+}
+
+func GetLatestTagOCI(path string, pre bool) (string, error) {
+	if debug {
+		fmt.Println("cache.GetLatestTagOCI:", path, pre)
+	}
+	tags, err := oci.ListTags(path)
+	if err != nil {
+		return "", err
+	}
+
+	best := ""
+	for _, n := range tags {
+		// skip any tags which do not start with v
+		if !strings.HasPrefix(n, "v") {
+			continue
+		}
+
+		// maybe filter prereleases
+		if !pre && semver.Prerelease(n) != "" {
+			continue
+		}
+
+		// update best?
+		if best == "" || semver.Compare(n, best) > 0 {
+			best = n	
+		}
+	}
+
+	return best, nil
+}
+	
+func GetLatestTagGit(path string, pre bool) (string, error) {
+	if debug {
+		fmt.Println("cache.GetLatestTagGit:", path, pre)
+	}
+
 	_, err := FetchRepoSource(path, "")
 	if err != nil {
 		return "", err
@@ -54,10 +113,41 @@ func GetLatestTag(path string, pre bool) (string, error) {
 	return best, nil
 }
 
-func GetLatestBranch(path, branch string) (string, error) {
+// return the hash for the named ref, either git branch or OCI non-semver tag
+func GetHashForNamedRef(path, ref string) (string, error) {
 	if debug {
-		fmt.Println("cache.GetLatestBranch", path, branch)
+		fmt.Println("cache.GetHashForNamedRef", path, ref)
 	}
+	rmt, err := remote.Parse(path)
+	if err != nil {
+		return "", fmt.Errorf("remote parse: %w", err)
+	}
+
+	kind, err := rmt.Kind()
+	if err != nil {
+		return "", fmt.Errorf("remote kind: %w", err)
+	}
+
+	switch kind {
+	case remote.KindGit:
+		return GetBranchLatestHash(path, ref)
+	case remote.KindOCI:
+		return GetNamedTagHashOCI(path, ref)
+	}
+
+	panic("cache.GetLatestBranch: should not get here")
+}
+
+func GetNamedTagHashOCI(path, tag string) (string, error) {
+	if debug {
+		fmt.Println("cache.GetNamedTagHashOCI:", path, tag)
+	}
+
+	return oci.GetRefHash(path, tag)
+}
+
+// this function returns the commit hash for a branch
+func GetBranchLatestHash(path, branch string) (string, error) {
 	// sync
 	_, err := FetchRepoSource(path, "")
 	if err != nil {
@@ -66,13 +156,13 @@ func GetLatestBranch(path, branch string) (string, error) {
 	// open repo
 	R, err := OpenRepoSource(path)
 	if err != nil {
-		return branch, fmt.Errorf("(glb) open source error: %w for %s@%s", err, path, branch)
+		return branch, fmt.Errorf("(gblh) open source error: %w for %s@%s", err, path, branch)
 	}
 
 	// get working tree
 	wt, err := R.Worktree()
 	if err != nil {
-		return branch, fmt.Errorf("(glb) worktree error: %w for %s@%s", err, path, branch)
+		return branch, fmt.Errorf("(gblh) worktree error: %w for %s@%s", err, path, branch)
 	}
 
 	// try to checkout branch
@@ -92,6 +182,10 @@ func GetLatestBranch(path, branch string) (string, error) {
 }
 
 func UpgradePseudoVersion(path, ver string) (s string, err error) {
+	if debug {
+		fmt.Println("cache.UpgradePsuedoVersion", path, ver)
+	}
+
 	// semver tag?
 	if semver.IsValid(ver) {
 		return ver, nil
@@ -105,7 +199,7 @@ func UpgradePseudoVersion(path, ver string) (s string, err error) {
 	}
 
 	// branch? need to find commit
-	nver, err := GetLatestBranch(path, ver)
+	nver, err := GetHashForNamedRef(path, ver)
 	if err != nil {
 		return ver, err
 	}

--- a/lib/repos/cache/load.go
+++ b/lib/repos/cache/load.go
@@ -26,7 +26,7 @@ var syncedRepos *sync.Map
 
 // CacheDir/{mod,src}
 
-var debug = false
+var debug = true
 
 func init() {
 	syncedRepos = new(sync.Map)
@@ -133,6 +133,7 @@ func CacheModule(url, ver string) (billy.Filesystem, error) {
 		}
 	}
 
+	fmt.Println("got here 1")
 	// we are smarter here and check to see if the tag already exists
 	// this will both clone new & sync existing repos as needed
 	// when ver != "", it will only fetch if the tag is not found
@@ -141,6 +142,7 @@ func CacheModule(url, ver string) (billy.Filesystem, error) {
 		return nil, err
 	}
 
+	fmt.Println("got here 2")
 	// fmt.Println("making:", url, ver)
 	ver, err = CopyRepoTag(url, ver)
 	if err != nil {

--- a/lib/repos/cache/load.go
+++ b/lib/repos/cache/load.go
@@ -10,6 +10,7 @@ import (
 	"github.com/go-git/go-billy/v5"
 	"github.com/go-git/go-billy/v5/osfs"
 
+	"github.com/hofstadter-io/hof/lib/repos/remote"
 	"github.com/hofstadter-io/hof/lib/repos/utils"
 )
 
@@ -26,7 +27,7 @@ var syncedRepos *sync.Map
 
 // CacheDir/{mod,src}
 
-var debug = true
+var debug = false
 
 func init() {
 	syncedRepos = new(sync.Map)
@@ -101,8 +102,34 @@ func Cache(url, ver string) (billy.Filesystem, error) {
 	if debug {
 		fmt.Println("cache.Cache:", url, ver)
 	}
+
+	s, err := UpgradePseudoVersion(url, ver)
+	if err != nil {
+		return nil, err
+	}
+	ver = s
+
+	if debug {
+		fmt.Println("cache.Cache version resolve:", url, ver)
+	}
+
 	if ver == "" {
-		return FetchRepoSource(url, ver)
+		rmt, err := remote.Parse(url)
+		if err != nil {
+			return nil, err
+		}
+
+		kind, err := rmt.Kind()
+		if err != nil {
+			return nil, err
+		}
+
+		switch kind {
+		case remote.KindGit:
+			return FetchRepoSource(url, ver)
+		case remote.KindOCI:
+			return FetchOCISource(url, ver)
+		}
 	}
 	return CacheModule(url, ver)
 }
@@ -111,8 +138,19 @@ func CacheModule(url, ver string) (billy.Filesystem, error) {
 	if debug {
 		fmt.Println("cache.CacheModule:", url, ver)
 	}
-	remote, owner, repo := utils.ParseModURL(url)
-	dir := ModuleOutdir(remote, owner, repo, ver)
+
+	s, err := UpgradePseudoVersion(url, ver)
+	if err != nil {
+		return nil, err
+	}
+	ver = s
+
+	if debug {
+		fmt.Println("cache.CacheModule version resolve:", url, ver)
+	}
+
+	reg, owner, repo := utils.ParseModURL(url)
+	dir := ModuleOutdir(reg, owner, repo, ver)
 
 	// check for existing directory
 	if _, err := os.Lstat(dir); err != nil {
@@ -133,21 +171,35 @@ func CacheModule(url, ver string) (billy.Filesystem, error) {
 		}
 	}
 
-	fmt.Println("got here 1")
-	// we are smarter here and check to see if the tag already exists
-	// this will both clone new & sync existing repos as needed
-	// when ver != "", it will only fetch if the tag is not found
-	_, err := FetchRepoSource(url, ver)
+	rmt, err := remote.Parse(url)
 	if err != nil {
 		return nil, err
 	}
 
-	fmt.Println("got here 2")
-	// fmt.Println("making:", url, ver)
-	ver, err = CopyRepoTag(url, ver)
+	kind, err := rmt.Kind()
 	if err != nil {
 		return nil, err
 	}
+
+	switch kind {
+	case remote.KindGit:
+		// we are smarter here and check to see if the tag already exists
+		// this will both clone new & sync existing repos as needed
+		// when ver != "", it will only fetch if the tag is not found
+		_, err := FetchRepoSource(url, ver)
+		if err != nil {
+			return nil, err
+		}
+
+		// fmt.Println("making:", url, ver)
+		ver, err = CopyRepoTag(url, ver)
+		if err != nil {
+			return nil, err
+		}
+	case remote.KindOCI:
+		return FetchOCISource(url, ver)
+	}
+
 
 	return Read(url, ver)
 }

--- a/lib/repos/oci/oci.go
+++ b/lib/repos/oci/oci.go
@@ -52,6 +52,7 @@ func IsNetworkReachable(mod string) (bool, error) {
 }
 
 func Pull(tag, path string) error {
+	fmt.Println("oci.Pull:", path)
 	ref, err := name.ParseReference(tag)
 	if err != nil {
 		return fmt.Errorf("name parse reference: %w", err)
@@ -88,13 +89,18 @@ func untar(r io.Reader, target string) error {
 		)
 
 		if i.IsDir() {
-			if err = os.MkdirAll(p, i.Mode()); err != nil {
+			if err = os.MkdirAll(p, 0755); err != nil {
 				return fmt.Errorf("mkdir all: %w", err)
 			}
 			continue
 		}
 
-		f, err := os.OpenFile(p, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, i.Mode())
+		// mkdir for file, in case we didn't get it first in the tar before the file
+		if err = os.MkdirAll(filepath.Dir(p), 0755); err != nil {
+			return fmt.Errorf("mkdir all: %w", err)
+		}
+
+		f, err := os.OpenFile(p, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0644)
 		if err != nil {
 			return fmt.Errorf("open file: %w", err)
 		}

--- a/lib/repos/remote/mirrors.go
+++ b/lib/repos/remote/mirrors.go
@@ -17,10 +17,24 @@ var (
 	mirrorsGit = []string{
 		"github.com",
 		"gitlab.com",
-		"bitbucket.com",
+		"bitbucket.org",
 	}
 	mirrorsOCI = []string{}
+
+	MirrorsSingleton *Mirrors
 )
+
+func init() {
+	// TODO, this should be a singleton for the application
+	// right now, we read the file every time we parse a mod path
+	var err error
+	MirrorsSingleton, err = NewMirrors()
+	if err != nil {
+		panic(err)
+		// return nil, fmt.Errorf("new mirrors: %w", err)
+	}
+
+}
 
 const (
 	hofDir             = "hof"

--- a/lib/repos/remote/remote.go
+++ b/lib/repos/remote/remote.go
@@ -3,6 +3,7 @@ package remote
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/hofstadter-io/hof/lib/repos/git"
@@ -58,7 +59,14 @@ func (r *Remote) Pull(ctx context.Context, dir, ver string) error {
 			return fmt.Errorf("git sync source: %w", err)
 		}
 	case KindOCI:
-		if err := oci.Pull(r.mod, dir); err != nil {
+		// extract hash from version
+		if strings.HasPrefix(ver, "v0.0.0-") {
+			parts := strings.Split(ver, "-")
+			ver = parts[len(parts)-1]
+			// HACK
+			ver = "sha256:" + ver
+		}
+		if err := oci.Pull(r.mod + "@" + ver, dir); err != nil {
 			return fmt.Errorf("oci pull: %w", err)
 		}
 

--- a/lib/repos/remote/remote.go
+++ b/lib/repos/remote/remote.go
@@ -10,50 +10,25 @@ import (
 	"github.com/hofstadter-io/hof/lib/repos/utils"
 )
 
+
 // Parse parses a module name and returns
 // the appropriate remote for it.
 func Parse(mod string) (*Remote, error) {
-	// TODO: Should pass a context in.
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
 
-	m, err := NewMirrors()
-	if err != nil {
-		return nil, fmt.Errorf("new mirrors: %w", err)
-	}
 
 	// TODO: Is is worth having a complex type here to handle
 	// this kind of check? Will Mirrors get used elsewhere?
 	// If not, it would be better to simplify Mirrors to a
 	// function.
-	defer m.Close()
+	// defer m.Close()
 
-	r := Remote{
-		mod:     mod,
-		mirrors: m,
+	r := NewRemote(mod, MirrorsSingleton)
+	_, err := r.Kind()
+	if err != nil {
+		return nil, err
 	}
 
-	r.Host, r.Owner, r.Name = utils.ParseModURL(mod)
-
-	isOCI, err := m.Is(ctx, KindOCI, mod)
-	if isOCI && err != nil {
-		return nil, fmt.Errorf("mirror is oci: %w", err)
-	}
-	if isOCI {
-		r.kind = KindOCI
-		return &r, nil
-	}
-
-	isGit, err := m.Is(ctx, KindGit, mod)
-	if isGit && err != nil {
-		return nil, fmt.Errorf("mirror is git: %w", err)
-	}
-	if isGit {
-		r.kind = KindGit
-		return &r, nil
-	}
-
-	return nil, fmt.Errorf("cannot parse %s", mod)
+	return r, nil
 }
 
 type Remote struct {
@@ -64,6 +39,16 @@ type Remote struct {
 	mod     string
 	kind    Kind
 	mirrors *Mirrors
+}
+
+func NewRemote(mod string, mir *Mirrors) *Remote {
+	r := &Remote{
+		mod:     mod,
+		mirrors: mir,
+	}
+
+	r.Host, r.Owner, r.Name = utils.ParseModURL(mod)
+	return r
 }
 
 func (r *Remote) Pull(ctx context.Context, dir, ver string) error {
@@ -105,6 +90,36 @@ func (r *Remote) Publish(ctx context.Context, dir string, tag string) error {
 	}
 
 	return fmt.Errorf("unsupported kind: %s", r.kind)
+}
+
+func (r *Remote) Kind() (Kind, error) {
+	if r.kind != "" {
+		return  r.kind, nil
+	}
+
+	// TODO: Should pass a context in.
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	isOCI, err := r.mirrors.Is(ctx, KindOCI, r.mod)
+	if isOCI && err != nil {
+		return "", fmt.Errorf("mirror is oci: %w", err)
+	}
+	if isOCI {
+		r.kind = KindOCI
+		return "", nil
+	}
+
+	isGit, err := r.mirrors.Is(ctx, KindGit, r.mod)
+	if isGit && err != nil {
+		return "", fmt.Errorf("mirror is git: %w", err)
+	}
+	if isGit {
+		r.kind = KindGit
+		return "", nil
+	}
+
+	return "", fmt.Errorf("cannot determine registry kind for: %s", r.mod)
 }
 
 type Kind string


### PR DESCRIPTION
These changes try to move most remote type, path, and version manipulations to the cache package.

When we fix mirrors, it should be here. The cache package is like the glue. Maybe mirrors.json management should move here? (probably note, the remote package does the type & path manip, versions depend on the remote type, so helpers are located there)