### PR TITLE
fix: Parse correct value for `HOF_FMT_DISABLED`

### DIFF
--- a/lib/fmt/fmtrs.go
+++ b/lib/fmt/fmtrs.go
@@ -64,7 +64,7 @@ func init() {
 
 	val := os.Getenv("HOF_FMT_DISABLED")
 	if val != "" {
-		dv, err := strconv.ParseBool(ds)
+		dv, err := strconv.ParseBool(val)
 		if err != nil {
 			fmt.Println("Error parsing HOF_FMT_DISABLED:", err)
 		} else {


### PR DESCRIPTION
It seems `ds` was mistakenly used instead of `val` here.