### PR TITLE
#fix : update patch.go to call PatchValue correctly

### DIFF
--- a/flow/tasks/st/patch.go
+++ b/flow/tasks/st/patch.go
@@ -21,9 +21,9 @@ func (T *Patch) Run(ctx *hofcontext.Context) (interface{}, error) {
 	v := ctx.Value
 
 	o := v.LookupPath(cue.ParsePath("orig"))
-	n := v.LookupPath(cue.ParsePath("patch"))
+	p := v.LookupPath(cue.ParsePath("patch"))
 
-	r, err := structural.PatchValue(o, n, nil)
+	r, err := structural.PatchValue(p, o, nil)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
# issue

PatchValue accepts (patch, val, ...), but was receiving (val, patch). 

this is predicated on `orig` being the data getting patched, and `patch` being the patch plan, (as if generated by diff).

# test

```
exec hof flow patch.cue
cmp stdout stdout.golden

-- stdout.golden --
P.next: {
    b: "b"
    e: {
            a: "a"
            b: "b"
            c: "c"
    }
    f: "new"
}

-- patch.cue --
package patch

// original thing being patched
o: {
    a: "a"
    b: "b"
    e: {
        a: "a"
        b: "b"
        d: "d"
    }
}

// update structure
p: {
    "-": {
        a: "a"    // remove field 'a'
    }
    e: {
        "-": {
            d: "d"    // remove nested field 'd'
        }
        "+": {
            c: "c"    // add new nested field 'c'
        }
    }
    "+": {
        f: "new"     // add new field 'f'
    }
}

@flow()
P: {
  @task(st.Patch)
  orig: o
  patch: p
  next: _
} @print(next)

// Result after patch
n: {
    b: "b"
    e: {
        a: "a"
        b: "b"
        c: "c"
    }
    f: "new"
}
// validation
n: P.next
```