### PR TITLE
#fix : update patch.go to call PatchValue correctly

### DIFF
--- a/flow/tasks/st/patch.go
+++ b/flow/tasks/st/patch.go
@@ -21,9 +21,9 @@ func (T *Patch) Run(ctx *hofcontext.Context) (interface{}, error) {
 	v := ctx.Value
 
 	o := v.LookupPath(cue.ParsePath("orig"))
-	n := v.LookupPath(cue.ParsePath("patch"))
+	p := v.LookupPath(cue.ParsePath("patch"))
 
-	r, err := structural.PatchValue(o, n, nil)
+	r, err := structural.PatchValue(p, o, nil)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
PatchValue accepts (patch, val, ...), but was receiving (val, patch). 

this is predicated on `orig` being the data getting patched, and `patch` being the patch plan, (as if generated by diff).