### PR TITLE
script/runtime: add Go 1.26 testDeps ModulePath

### DIFF
--- a/script/runtime/exe_go126.go
+++ b/script/runtime/exe_go126.go
@@ -1,0 +1,10 @@
+// Copyright 2018 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build go1.26
+
+package runtime
+
+// ModulePath was added to testing.testDeps in Go 1.26.
+func (nopTestDeps) ModulePath() string { return "" }


### PR DESCRIPTION
seeing the build failure against go1.26rc1

```
==> go build -trimpath -o=/opt/homebrew/Cellar/hof/HEAD-1613a4e/bin/hof -ldflags=-s -w -X github.com/hofstadter-io/hof/cmd/hof/verinfo.Version=HEAD-1613a4e -X github.com/hofstadter-io/hof/cmd/hof/verinfo.Commit=Homebrew -X github.com/hofstadter-io/hof/cmd/hof/verinfo.BuildDate=2024-12-31T22:09:53Z -X github.com/hofstadter-io/hof/cmd/hof/verinfo.GoVersion=1.26rc1 -X github.com/hofstadter-io/hof/cmd/hof/verinfo.BuildOS=darwin -X github.com/hofstadter-io/hof/cmd/hof/verinfo.BuildArch=arm64 ./cmd/hof
# github.com/hofstadter-io/hof/script/runtime
script/runtime/exe_next.go:52:26: cannot use nopTestDeps{} (value of struct type nopTestDeps) as testing.testDeps value in argument to testing.MainStart: nopTestDeps does not implement testing.testDeps (missing method ModulePath)
```

relates to 
- https://github.com/Homebrew/homebrew-core/pull/258912
- https://github.com/Homebrew/homebrew-core/pull/260266